### PR TITLE
Feature added: default values

### DIFF
--- a/lib/delocalize/rails_ext/time_zone.rb
+++ b/lib/delocalize/rails_ext/time_zone.rb
@@ -1,7 +1,7 @@
 require 'delocalize/localized_date_time_parser'
 
 ActiveSupport::TimeZone.class_eval do
-  def parse_localized(time_with_zone)
-    Delocalize::LocalizedDateTimeParser.parse(time_with_zone, self.class)
+  def parse_localized(time_with_zone, defaults={})
+    Delocalize::LocalizedDateTimeParser.parse(time_with_zone, self.class, defaults)
   end
 end

--- a/lib/delocalize/ruby_ext/date.rb
+++ b/lib/delocalize/ruby_ext/date.rb
@@ -2,8 +2,8 @@ require 'delocalize/localized_date_time_parser'
 
 Date.class_eval do
   class << self
-    def parse_localized(date)
-      Delocalize::LocalizedDateTimeParser.parse(date, self)
+    def parse_localized(date, defaults={})
+      Delocalize::LocalizedDateTimeParser.parse(date, self, defaults)
     end
   end
 end

--- a/lib/delocalize/ruby_ext/datetime.rb
+++ b/lib/delocalize/ruby_ext/datetime.rb
@@ -2,8 +2,8 @@ require 'delocalize/localized_date_time_parser'
 
 DateTime.class_eval do
   class << self
-    def parse_localized(datetime)
-      Delocalize::LocalizedDateTimeParser.parse(datetime, self)
+    def parse_localized(datetime, defaults={})
+      Delocalize::LocalizedDateTimeParser.parse(datetime, self, defaults)
     end
   end
 end

--- a/lib/delocalize/ruby_ext/time.rb
+++ b/lib/delocalize/ruby_ext/time.rb
@@ -2,8 +2,8 @@ require 'delocalize/localized_date_time_parser'
 
 Time.class_eval do
   class << self
-    def parse_localized(time)
-      Delocalize::LocalizedDateTimeParser.parse(time, self)
+    def parse_localized(time, defaults={})
+      Delocalize::LocalizedDateTimeParser.parse(time, self, defaults)
     end
   end
 end

--- a/test/delocalize_test.rb
+++ b/test/delocalize_test.rb
@@ -2,6 +2,30 @@
 
 require File.expand_path(File.join(File.dirname(__FILE__), 'test_helper'))
 
+class DelocalizeDateParseTest < Test::Unit::TestCase
+  def setup
+    Time.zone = 'Berlin'
+  end
+  
+  def test_time_parsing_should_use_defaults
+    t = Time.zone.parse_localized("2010/8/16",{:hour=>13,:min=>37})
+    assert_equal Time.zone.local(2010,8,16,13,37,0),t
+    
+    t = Time.zone.parse_localized("16.08.2010",{:hour=>13,:min=>37})
+    assert_equal Time.zone.local(2010,8,16,13,37,0),t
+    
+    t = Time.zone.parse_localized("09:31 Uhr",{:year=>2010,:mon=>2, :mday=>4})
+    assert_equal Time.zone.local(2010,2,4,9,31,0),t
+  end
+  
+  def test_time_parsing_should_use_today_as_default_day_if_no_other_day_given
+    today = Date.current
+    t = Time.zone.parse_localized("09:31 Uhr")
+    assert_equal Time.zone.local(today.year,today.mon,today.mday,9,31,0),t
+  end
+  
+end
+
 class DelocalizeActiveRecordTest < ActiveRecord::TestCase
   def setup
     Time.zone = 'Berlin' # make sure everything works as expected with TimeWithZone

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,14 +29,15 @@ I18n.backend.store_translations :de, {
   },
   :time => {
     :input => {
-      :formats => [:long, :medium, :short, :default, :time]
+      :formats => [:long, :medium, :short, :default, :time, :date_only]
     },
     :formats => {
       :default => "%A, %e. %B %Y, %H:%M Uhr",
       :short => "%e. %B, %H:%M Uhr",
       :medium => "%e. %B %Y, %H:%M Uhr",
       :long => "%A, %e. %B %Y, %H:%M Uhr",
-      :time => "%H:%M Uhr"
+      :time => "%H:%M Uhr",
+      :date_only => "%d.%m.%Y"
     },
     :am => 'vormittags',
     :pm => 'nachmittags'


### PR DESCRIPTION
Hi there's
I added a 'defaults' param to all Date/Time parsing methods. This is usefull, if you want to allow partial dates to be valid, but not use today or 0 as default value for missing fragments.
Example:
You have "%d.%m.%Y" as valid time format. Before this commit "12.4.2009" would be parsed to "Sun, 12 Apr 2009 00:00:00". After this commit you could for example provide a default time. The following code
      Time.zone.parse("12.4.2009",{:hour=>18,:min=>30})
would be then evaluated to "Sun, 12 Apr 2009 18:30:00".

Do you have any questions?

Greetings
HannesG
