### PR TITLE
Fix bug where change tracking would fail

### DIFF
--- a/lib/delocalize/rails_ext/active_record.rb
+++ b/lib/delocalize/rails_ext/active_record.rb
@@ -54,8 +54,10 @@ ActiveRecord::Base.class_eval do
         # If an old value of 0 is set to '' we want this to get changed to nil as otherwise it'll
         # be typecast back to 0 (''.to_i => 0)
         value = nil
-      else
+      elsif column.number?
         value = column.type_cast(convert_number_column_value_with_localization(value))
+      else
+        value = column.type_cast(value)
       end
     end
 

--- a/test/delocalize_test.rb
+++ b/test/delocalize_test.rb
@@ -141,6 +141,13 @@ class DelocalizeActiveRecordTest < ActiveRecord::TestCase
     assert @product.weight_changed?
   end
 
+  test "attributes that didn't change shouldn't be marked dirty" do
+    @product.name = "Good cookies, Really good"
+    @product.save
+    @product.name = "Good cookies, Really good"
+    assert !@product.name_changed?
+  end
+
   test "should remember the value before type cast" do
     @product.price = "asd"
     assert_equal @product.price, 0


### PR DESCRIPTION
If your seperator is a , and you had a "foo, bar" string, it would be converted to "foo bar" and it could be incorrectly marked as changed. This commit changes that.
