### PR TITLE
Fix remove_method error

### DIFF
--- a/lib/delocalize/delocalizable.rb
+++ b/lib/delocalize/delocalizable.rb
@@ -39,9 +39,7 @@ module Delocalize
         writer_method = "#{field}="
 
         class_eval <<-ruby, __FILE__, __LINE__ + 1
-          if method_defined?(:#{writer_method})
-            remove_method(:#{writer_method})
-          end
+          remove_possible_method(:#{writer_method})
 
           def #{writer_method}(value)
             if Delocalize.enabled? && delocalizes?(:#{field})


### PR DESCRIPTION
As noted in http://api.rubyonrails.org/classes/Module.html#method-i-remove_possible_method

> If the requested method is defined on a superclass or included module, method_defined? returns true but remove_method throws a NameError. Ignore this.

This fix is necessary to make Delocalize work with Mongoid (Mongoid defines attribute writers on an included module, not on the model class itself).
