### PR TITLE
Handle I18n Fallbacks

### DIFF
--- a/lib/delocalize/localized_date_time_parser.rb
+++ b/lib/delocalize/localized_date_time_parser.rb
@@ -53,7 +53,10 @@ module Delocalize
       end
 
       def translate_month_and_day_names(datetime)
-        translated = I18n.t([:month_names, :abbr_month_names, :day_names, :abbr_day_names], :scope => :date).flatten.compact
+        translated = [:month_names, :abbr_month_names, :day_names, :abbr_day_names].map do |key|
+          I18n.t(key, :scope => :date)
+        end.flatten.compact
+
         original = (Date::MONTHNAMES + Date::ABBR_MONTHNAMES + Date::DAYNAMES + Date::ABBR_DAYNAMES).compact
         translated.each_with_index { |name, i| datetime.gsub!(name, original[i]) }
       end

--- a/test/delocalize_test.rb
+++ b/test/delocalize_test.rb
@@ -59,6 +59,17 @@ class DelocalizeActiveRecordTest < ActiveRecord::TestCase
     assert_equal time, @product.published_at
   end
 
+  test "delocalizes with fallback locale" do
+    I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
+    I18n.fallbacks[:xx] = [:xx, :tt]
+
+    I18n.with_locale :xx do
+      @product.released_on = '10|11|2009'
+      date = Date.civil(2009, 11, 10)
+      assert_equal date, @product.released_on
+    end
+  end
+
   test "delocalizes localized datetime without year" do
     time = Time.zone.local(Date.today.year, 3, 1, 12, 0, 0)
 


### PR DESCRIPTION
Fixes an issue where an exception was being raised for a non-matching key, without trying to match the key against the fallbacks.
