### PR TITLE
Additional format options for attributes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,6 +45,14 @@ Delocalize does most of this under the covers. All you need is a simple declarat
       delocalize :price => :number, :released_on => :date, :published_at => :time
     end
 
+It is also possible to specify additional format options for attributes:
+
+    delocalize :price => {:type => :number, :precision => 0},
+               :released_on => {:type => :date, :format => "%d.%m.%Y"}
+
+The additional options are simply passed through to `number_with_precision` (for numbers) or `I18n.l` (for dates and times).
+
+
 ### Usage outside of Rails/ActiveRecord
 
 Delocalize should – in theory – work independently of Rails and ActiveRecord.

--- a/lib/delocalize/action_view.rb
+++ b/lib/delocalize/action_view.rb
@@ -31,9 +31,12 @@ ActionView::Helpers::InstanceTag.class_eval do
 
     case type
     when :number
-      options[:value] = number_with_precision(value)
+      options[:value] = number_with_precision(value, object.delocalize_options_for(method_name))
     when :date, :time
-      options[:value] = value ? I18n.l(value, :format => options.delete(:format) || :default) : nil
+      localize_options = object.delocalize_options_for(method_name).dup
+      localize_options[:format] ||= :default
+      localize_options[:format] = options.delete(:format) if options[:format]
+      options[:value] = value ? I18n.l(value, localize_options) : nil
     end
 
     original_to_input_field_tag(field_type, options)

--- a/lib/delocalize/delocalizable.rb
+++ b/lib/delocalize/delocalizable.rb
@@ -5,17 +5,26 @@ module Delocalize
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :delocalizable_fields
       class_attribute :delocalize_conversions
+      class_attribute :delocalize_options
+      class_attribute :delocalizable_fields
       self.delocalize_conversions = {}
+      self.delocalize_options = {}
       self.delocalizable_fields = []
     end
 
     module ClassMethods
       def delocalize(conversions = {})
-        conversions.each do |field, type|
+        conversions.each do |field, options|
           delocalizable_fields << field.to_sym unless delocalizable_fields.include?(field.to_sym)
+          if options.is_a?(Hash)
+            type = options.delete(:type)
+          else
+            type = options
+            options = {}
+          end
           delocalize_conversions[field.to_sym] = type.to_sym
+          delocalize_options[field.to_sym] = options
           define_delocalize_attr_writer field.to_sym
         end
       end
@@ -30,6 +39,10 @@ module Delocalize
 
       def delocalize_type_for(field)
         delocalize_conversions[field.to_sym]
+      end
+
+      def delocalize_options_for(field)
+        delocalize_options[field.to_sym]
       end
 
     private
@@ -72,6 +85,10 @@ module Delocalize
 
       def delocalize_type_for(field)
         self.class.delocalize_type_for(field)
+      end
+
+      def delocalize_options_for(field)
+        self.class.delocalize_options_for(field)
       end
     end
   end

--- a/test/delocalizable_test.rb
+++ b/test/delocalizable_test.rb
@@ -13,35 +13,35 @@ class DelocalizableTest < ActiveSupport::TestCase
   end
 
   test "stores the delocalizable fields" do
-    DelocalizableClass.delocalize :foo => :number, :bar => :time
+    DelocalizableClass.delocalize :foo => :number, :bar => {:type => :time}
     assert_equal [:foo, :bar], DelocalizableClass.delocalizable_fields
   end
 
   test "stores the delocalizable fields as symbols" do
-    DelocalizableClass.delocalize 'foo' => 'number', 'bar' => 'time'
+    DelocalizableClass.delocalize 'foo' => 'number', 'bar' => {:type => 'time'}
     assert_equal [:foo, :bar], DelocalizableClass.delocalizable_fields
   end
 
   test "stores the delocalizable fields without overriding existing ones" do
-    DelocalizableClass.delocalize :foo => :number, :bar => :time
+    DelocalizableClass.delocalize :foo => :number, :bar => {:type => :time}
     DelocalizableClass.delocalize :baz => :date
     assert_equal [:foo, :bar, :baz], DelocalizableClass.delocalizable_fields
   end
 
   test "stores the delocalizable fields without duplicates" do
-    DelocalizableClass.delocalize :foo => :number, :bar => :time
+    DelocalizableClass.delocalize :foo => :number, :bar => {:type => :time}
     DelocalizableClass.delocalize :foo => :date
     assert_equal [:foo, :bar], DelocalizableClass.delocalizable_fields
   end
 
   test "stores conversions" do
-    DelocalizableClass.delocalize :foo => :number, :bar => :time
+    DelocalizableClass.delocalize :foo => :number, :bar => {:type => :time}
     assert_equal :number, DelocalizableClass.delocalize_conversions[:foo]
     assert_equal :time, DelocalizableClass.delocalize_conversions[:bar]
   end
 
   test "stores conversions as symbols" do
-    DelocalizableClass.delocalize 'foo' => 'number', 'bar' => 'time'
+    DelocalizableClass.delocalize 'foo' => 'number', 'bar' => {:type => 'time'}
     assert_equal :number, DelocalizableClass.delocalize_conversions[:foo]
     assert_equal :time, DelocalizableClass.delocalize_conversions[:bar]
   end
@@ -50,6 +50,17 @@ class DelocalizableTest < ActiveSupport::TestCase
     DelocalizableClass.delocalize :foo => :number
     DelocalizableClass.delocalize :foo => :date
     assert_equal :date, DelocalizableClass.delocalize_conversions[:foo]
+  end
+
+  test "stores options" do
+    DelocalizableClass.delocalize :foo => {:type => :number, :any_option => 23}
+    assert_equal({:any_option => 23}, DelocalizableClass.delocalize_options[:foo])
+  end
+
+  test "stores options and overrides previous settings" do
+    DelocalizableClass.delocalize :foo => {:type => :number, :any_option => 23}
+    DelocalizableClass.delocalize :foo => {:type => :date, :other_option => 42}
+    assert_equal({:other_option => 42}, DelocalizableClass.delocalize_options[:foo])
   end
 
   test "defines attribute writers" do

--- a/test/delocalize_test.rb
+++ b/test/delocalize_test.rb
@@ -202,11 +202,9 @@ class DelocalizeActionViewTest < ActionView::TestCase
   end
 
   test "shows text field using formatted number with options" do
-    pending 'not sure I want this right now'
-
-    @product.price = 1299.995
-    assert_dom_equal '<input id="product_price" name="product[price]" size="30" type="text" value="1,299.995" />',
-      text_field(:product, :price, :precision => 3, :delimiter => ',', :separator => '.')
+    @product.count = 1001.0
+    assert_dom_equal '<input id="product_count" name="product[count]" size="30" type="text" value="1.001" />',
+      text_field(:product, :count)
   end
 
   test "shows text field using formatted number without precision if column is an integer" do
@@ -225,6 +223,18 @@ class DelocalizeActionViewTest < ActionView::TestCase
     @product.released_on = Date.civil(2009, 10, 19)
     assert_dom_equal '<input id="product_released_on" name="product[released_on]" size="30" type="text" value="19.10.2009" />',
       text_field(:product, :released_on)
+  end
+
+  test "shows text field using formatted date with options" do
+    @product.created_on = Date.civil(2009, 10, 19)
+    assert_dom_equal '<input id="product_created_on" name="product[created_on]" size="30" type="text" value="19. Oktober 2009" />',
+      text_field(:product, :created_on)
+  end
+
+  test "shows text field using formatted date with format overriding options" do
+    @product.created_on = Date.civil(2009, 10, 19)
+    assert_dom_equal '<input id="product_created_on" name="product[created_on]" size="30" type="text" value="19. Okt" />',
+      text_field(:product, :created_on, :format => :short)
   end
 
   test "shows text field using formatted date and time" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,7 +71,8 @@ end
 
 class Product < ActiveRecord::Base
   delocalize :price => :number, :weight => :number, :times_sold => :number, :some_value_with_default => :number,
-             :released_on => :date, :published_at => :time, :cant_think_of_a_sensible_time_field => :time
+             :released_on => :date, :published_at => :time, :cant_think_of_a_sensible_time_field => :time,
+             :count => { :type => :number, :precision => 0 }, :created_on => { :type => :date, :format => "%d. %B %Y" }
 end
 
 class ProductWithValidation < Product
@@ -85,10 +86,12 @@ ActiveRecord::Base.establish_connection(config['test'])
 ActiveRecord::Base.connection.create_table :products do |t|
   t.string :name
   t.date :released_on
+  t.date :created_on
   t.datetime :published_at
   t.time :cant_think_of_a_sensible_time_field
   t.decimal :price
   t.float :weight
   t.integer :times_sold
+  t.integer :count
   t.decimal :some_value_with_default, :default => 13.37, :precision => 20, :scale => 2
 end


### PR DESCRIPTION
This is a fairly large pull request and I’m not sure if you want this kind of feature in delocalize at all :-)

I need custom formatting for some delocalized number attributes, and I’d rather specify those options in the model class instead of adding format options when using `text_field`.

New, extended syntax for `delocalize`:
````ruby
# Delocalize price (using default format) and count (using additional format options)
delocalize :price => :number, :count => {:type => :number, :precision => 0}
````
Additional options, if any, are simply passed through to `number_with_precision` or `I18n.l` (options specified when calling `text_field` take precedence).

The change should be fully backward compatible.