### PR TITLE
Define delocalizing attribute writers in module, so they can be overridden.

### DIFF
--- a/lib/delocalize/delocalizable.rb
+++ b/lib/delocalize/delocalizable.rb
@@ -43,18 +43,15 @@ module Delocalize
 
     private
 
-      def delocalize_attribute_writers
-        @delocalize_attribute_writers ||= begin
-          mod = Module.new
-          include(mod)
-          mod
-        end
-      end
-
       def define_delocalize_attr_writer(field)
         writer_method = "#{field}="
 
-        delocalize_attribute_writers.module_eval <<-ruby, __FILE__, __LINE__ + 1
+        # Define the attribute writers in an included module - this makes
+        # it possible to override them in model classes and still use
+        # delocalize functionality (by calling `super`).
+        @delocalize_attribute_writers ||= Module.new.tap{|mod| include(mod)}
+
+        @delocalize_attribute_writers.module_eval <<-ruby, __FILE__, __LINE__ + 1
           remove_possible_method(:#{writer_method})
 
           def #{writer_method}(value)

--- a/lib/delocalize/delocalizable.rb
+++ b/lib/delocalize/delocalizable.rb
@@ -43,10 +43,18 @@ module Delocalize
 
     private
 
+      def delocalize_attribute_writers
+        @delocalize_attribute_writers ||= begin
+          mod = Module.new
+          include(mod)
+          mod
+        end
+      end
+
       def define_delocalize_attr_writer(field)
         writer_method = "#{field}="
 
-        class_eval <<-ruby, __FILE__, __LINE__ + 1
+        delocalize_attribute_writers.module_eval <<-ruby, __FILE__, __LINE__ + 1
           remove_possible_method(:#{writer_method})
 
           def #{writer_method}(value)

--- a/test/delocalize_test.rb
+++ b/test/delocalize_test.rb
@@ -185,6 +185,14 @@ class DelocalizeActiveRecordTest < ActiveRecord::TestCase
     assert_equal @product.price, 0
     assert_equal @product.price_before_type_cast, "asd"
   end
+
+  test "overriding attribute writers should be possible" do
+    @product = ProductWithOverriddenPriceWriter.new
+    assert !@product.price_writer_has_been_called
+    @product.price = "123,45"
+    assert @product.price_writer_has_been_called
+    assert_equal 123.45, @product.price
+  end
 end
 
 class DelocalizeActionViewTest < ActionView::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -79,6 +79,15 @@ class ProductWithValidation < Product
   validates_presence_of :price
 end
 
+class ProductWithOverriddenPriceWriter < Product
+  attr_accessor :price_writer_has_been_called
+
+  def price=(val)
+    self.price_writer_has_been_called = true
+    super
+  end
+end
+
 config = YAML.load_file(File.dirname(__FILE__) + '/database.yml')
 ActiveRecord::Base.establish_connection(config['test'])
 


### PR DESCRIPTION
Inspired by Mongoid, which uses the same pattern for its attribute writers.

See https://github.com/mongoid/mongoid/blob/v3.0.4/lib/mongoid/fields.rb#L425-439