### PR TITLE
Make sure class attributes are not shared between subclasses.

### DIFF
--- a/lib/delocalize/delocalizable.rb
+++ b/lib/delocalize/delocalizable.rb
@@ -4,13 +4,6 @@ module Delocalize
   module Delocalizable
     extend ActiveSupport::Concern
 
-    included do
-      class_attribute :delocalizable_fields
-      class_attribute :delocalize_conversions
-      self.delocalize_conversions = {}
-      self.delocalizable_fields = []
-    end
-
     module ClassMethods
       def delocalize(conversions = {})
         conversions.each do |field, type|
@@ -30,6 +23,22 @@ module Delocalize
 
       def delocalize_type_for(field)
         delocalize_conversions[field.to_sym]
+      end
+
+      def delocalizable_fields
+        @delocalizable_fields ||= if superclass.respond_to?(:delocalizable_fields)
+          superclass.delocalizable_fields.dup
+        else
+          []
+        end
+      end
+
+      def delocalize_conversions
+        @delocalize_conversions ||= if superclass.respond_to?(:delocalize_conversions)
+          superclass.delocalize_conversions.dup
+        else
+          {}
+        end
       end
 
     private

--- a/test/delocalizable_test.rb
+++ b/test/delocalizable_test.rb
@@ -32,6 +32,15 @@ class DelocalizableTest < ActiveSupport::TestCase
     assert_equal [:foo, :bar], @delocalizable_class.delocalizable_fields
   end
 
+  test "inheriting delocalizable fields works correctly" do
+    @delocalizable_class.delocalize :base => :number
+    foo_class = Class.new(@delocalizable_class) { delocalize :foo => :number }
+    bar_class = Class.new(@delocalizable_class) { delocalize :bar => :number }
+    assert_equal [:base], @delocalizable_class.delocalizable_fields
+    assert_equal [:base, :foo], foo_class.delocalizable_fields
+    assert_equal [:base, :bar], bar_class.delocalizable_fields
+  end
+
   test "stores conversions" do
     @delocalizable_class.delocalize :foo => :number, :bar => :time
     assert_equal :number, @delocalizable_class.delocalize_conversions[:foo]
@@ -48,6 +57,15 @@ class DelocalizableTest < ActiveSupport::TestCase
     @delocalizable_class.delocalize :foo => :number
     @delocalizable_class.delocalize :foo => :date
     assert_equal :date, @delocalizable_class.delocalize_conversions[:foo]
+  end
+
+  test "inheriting conversions works correctly" do
+    @delocalizable_class.delocalize :foo => :number
+    foo_class = Class.new(@delocalizable_class) { delocalize :foo => :date }
+    bar_class = Class.new(@delocalizable_class) { delocalize :bar => :time }
+    assert_equal({:foo => :number}, @delocalizable_class.delocalize_conversions)
+    assert_equal({:foo => :date}, foo_class.delocalize_conversions)
+    assert_equal({:foo => :number, :bar => :time}, bar_class.delocalize_conversions)
   end
 
   test "defines attribute writers" do


### PR DESCRIPTION
Using `class_attribute` with arrays or hashes is tricky, as mutating the object will change the object of the superclass (which may be shared by other subclasses, too).

I discovered this bug while experimenting with the metaprogramming stuff related to [my recent pull request](https://github.com/clemens/delocalize/pull/49) :-)

First I suspected that this bug was introduced by me in https://github.com/clemens/delocalize/pull/43 – but has been around before (the pull request only changed the original buggy behaviour to a slightly different buggy behaviour …).

On a side note: Using Delocalize with Mongoid is unaffected – the bug only appears when the `Delocalize::Delocalizable` module is included in `ActiveRecord::Base` and thus shared by subclasses. 
With the overall trend going to “including instead of inheriting” (see [ActiveRecord::Model](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/model.rb) for a prominent example) – what do you think about removing the ActiveRecord-Railtie entirely? 
