### PR TITLE
Adjusted compatibility with Rails version >= 3.2.9

### DIFF
--- a/lib/delocalize/rails_ext/active_record.rb
+++ b/lib/delocalize/rails_ext/active_record.rb
@@ -39,7 +39,7 @@ ActiveRecord::Base.class_eval do
   end
   alias_method_chain :convert_number_column_value, :localization
 
-  def field_changed?(attr, old, value)
+  def _field_changed?(attr, old, value)
     if column = column_for_attribute(attr)
       if column.number? && column.null && (old.nil? || old == 0) && value.blank?
         # For nullable numeric columns, NULL gets stored in database for blank (i.e. '') values.


### PR DESCRIPTION
Refers the issue #54. 
The change in Rails that caused the mismatch is seen here:
- https://github.com/rails/rails/blob/master/activerecord/lib/active_record/attribute_methods/dirty.rb#L87
- http://weblog.rubyonrails.org/2012/10/29/ann-rails-3-2-9-rc1-has-been-released/
