### PR TITLE
Ensure enable_delocalization is properly reset

### DIFF
--- a/lib/delocalize/i18n_ext.rb
+++ b/lib/delocalize/i18n_ext.rb
@@ -16,15 +16,21 @@ module I18n
     def with_delocalization_disabled(&block)
       old_value = I18n.enable_delocalization
       I18n.enable_delocalization = false
-      yield
-      I18n.enable_delocalization = old_value
+      begin
+        yield
+      ensure
+        I18n.enable_delocalization = old_value
+      end
     end
 
     def with_delocalization_enabled(&block)
       old_value = I18n.enable_delocalization
       I18n.enable_delocalization = true
-      yield
-      I18n.enable_delocalization = old_value
+      begin
+        yield
+      ensure
+        I18n.enable_delocalization = old_value
+      end
     end
   end
 end

--- a/test/delocalize_test.rb
+++ b/test/delocalize_test.rb
@@ -147,6 +147,14 @@ class DelocalizeActiveRecordTest < ActiveRecord::TestCase
     end
   end
 
+  test "properly resets when an error is raised in a with_delocalization_disabled block" do
+    I18n.enable_delocalization = true
+    I18n.with_delocalization_disabled do
+      raise 'error'
+    end rescue nil
+    assert_equal true, I18n.enable_delocalization
+  end
+
   test "uses localized parsing if called with with_delocalization_enabled" do
     I18n.with_delocalization_enabled do
       @product.price = '1.299,99'
@@ -155,6 +163,14 @@ class DelocalizeActiveRecordTest < ActiveRecord::TestCase
       @product.price = '-1.299,99'
       assert_equal -1299.99, @product.price
     end
+  end
+
+  test "properly resets when an error is raised in a with_delocalization_enabled block" do
+    I18n.enable_delocalization = false
+    I18n.with_delocalization_enabled do
+      raise 'error'
+    end rescue nil
+    assert_equal false, I18n.enable_delocalization
   end
 
   test "dirty attributes must detect changes in decimal columns" do


### PR DESCRIPTION
When the yielded block in with_delocalization_disabled/with_delocalization_enabled raises an error, the state of enable_delocalization gets out of sync.
