### PR TITLE
Allow fields_for-like attributes

### DIFF
--- a/lib/delocalize/parameter_delocalizing.rb
+++ b/lib/delocalize/parameter_delocalizing.rb
@@ -22,7 +22,16 @@ module Delocalize
     end
 
     def delocalize_parser_for(options, key_stack)
-      parser_type = key_stack.reduce(options) { |h, key| h.stringify_keys[key.to_s] }
+      parser_type = key_stack.reduce(options) do |h, key|
+        break unless h.is_a? Hash
+        h = h.stringify_keys
+        if key =~ /\A-?\d+\z/ && !h.key?(key.to_s)
+          h
+        else
+          h[key.to_s]
+        end
+      end
+
       return unless parser_type
 
       parser_name = "delocalize_#{parser_type}_parser"

--- a/lib/delocalize/parameter_delocalizing.rb
+++ b/lib/delocalize/parameter_delocalizing.rb
@@ -23,12 +23,14 @@ module Delocalize
 
     def delocalize_parser_for(options, key_stack)
       parser_type = key_stack.reduce(options) do |h, key|
-        break unless h.is_a? Hash
+        break unless h.is_a?(Hash)
+
         h = h.stringify_keys
-        if key =~ /\A-?\d+\z/ && !h.key?(key.to_s)
+        key = key.to_s
+        if key =~ /\A-?\d+\z/ && !h.key?(key)
           h
         else
-          h[key.to_s]
+          h[key]
         end
       end
 

--- a/test/parameters_test.rb
+++ b/test/parameters_test.rb
@@ -39,7 +39,7 @@ parameters_classes.each do |parameters_class|
           :product => {
               variant_attributes: {
                   "0" => { :released_on => '21. Mai 1986', :available_until => '25. Dezember 2013, 23:59 Uhr', :price => '1.299,99' },
-                  "1" => { :released_on => '21. Mai 1986', :available_until => '25. Dezember 2013, 23:59 Uhr', :price => '1.299,99' },
+                  "1" => { :released_on => '1. Juni 2001', :available_until => '12. November 2014, 00:00 Uhr', :price => '1.099,01' },
               }
           }
       )
@@ -50,9 +50,9 @@ parameters_classes.each do |parameters_class|
       delocalized_params[:product][:variant_attributes]['0'][:available_until].must_equal Time.zone.local(2013, 12, 25, 23, 59)
       delocalized_params[:product][:variant_attributes]['0'][:price].must_equal '1299.99'
 
-      delocalized_params[:product][:variant_attributes]['1'][:released_on].must_equal Date.civil(1986, 5, 21)
-      delocalized_params[:product][:variant_attributes]['1'][:available_until].must_equal Time.zone.local(2013, 12, 25, 23, 59)
-      delocalized_params[:product][:variant_attributes]['1'][:price].must_equal '1299.99'
+      delocalized_params[:product][:variant_attributes]['1'][:released_on].must_equal Date.civil(2001, 6, 1)
+      delocalized_params[:product][:variant_attributes]['1'][:available_until].must_equal Time.zone.local(2014, 11, 12, 00, 00)
+      delocalized_params[:product][:variant_attributes]['1'][:price].must_equal '1099.01'
     end
     
     it "delocalizes nested params on the key itself based on the given options" do

--- a/test/parameters_test.rb
+++ b/test/parameters_test.rb
@@ -34,6 +34,27 @@ parameters_classes.each do |parameters_class|
       delocalized_params[:product][:price].must_equal '1299.99'
     end
 
+    it "delocalizes field-for type params based on the given options" do
+      params = parameters_class.new(
+          :product => {
+              variant_attributes: {
+                  "0" => { :released_on => '21. Mai 1986', :available_until => '25. Dezember 2013, 23:59 Uhr', :price => '1.299,99' },
+                  "1" => { :released_on => '21. Mai 1986', :available_until => '25. Dezember 2013, 23:59 Uhr', :price => '1.299,99' },
+              }
+          }
+      )
+
+      delocalized_params = params.delocalize(:product => { :variant_attributes => { :released_on => :date, :available_until => :time, :price => :number } })
+
+      delocalized_params[:product][:variant_attributes]['0'][:released_on].must_equal Date.civil(1986, 5, 21)
+      delocalized_params[:product][:variant_attributes]['0'][:available_until].must_equal Time.zone.local(2013, 12, 25, 23, 59)
+      delocalized_params[:product][:variant_attributes]['0'][:price].must_equal '1299.99'
+
+      delocalized_params[:product][:variant_attributes]['1'][:released_on].must_equal Date.civil(1986, 5, 21)
+      delocalized_params[:product][:variant_attributes]['1'][:available_until].must_equal Time.zone.local(2013, 12, 25, 23, 59)
+      delocalized_params[:product][:variant_attributes]['1'][:price].must_equal '1299.99'
+    end
+    
     it "delocalizes nested params on the key itself based on the given options" do
       params = parameters_class.new(:product => { :released_on => '21. Mai 1986', :available_until => '25. Dezember 2013, 23:59 Uhr', :price => '1.299,99' })
 


### PR DESCRIPTION
Currently it is not possible to delocalize parameters which have been created by `fields_for` for a `has_many` association. For example this params hash could not be handled:
```
product: {
  variants_attributes: {
    '0' => {
      valid_until: '1. Januar 2015'
    },
    '1' => {
      valid_until: '3. Januar 2015'
    }
  }
}
```

With this patch it can be delocalized via:

```
delocalize(product: { variants_attributes: { valid_until: :date } })
```

The mechanism was inspired by `strong_parameters`, also the fix from https://github.com/clemens/delocalize/pull/72 is integrated.