### PR TITLE
Allow delocalization of arrays 

### DIFF
--- a/test/parameters_test.rb
+++ b/test/parameters_test.rb
@@ -158,5 +158,14 @@ parameters_classes.each do |parameters_class|
       ## Should not throw an error:
       delocalized_params = params.delocalize({})
     end
+
+    it "delocalizes arrays" do
+      params = parameters_class.new(:location => ['13,456', '51,234'], :interval => ['25. Dezember 2013', '31. Januar 2014'])
+
+      delocalized_params = params.delocalize(:location => [:number], interval: [:date])
+
+      delocalized_params[:location].must_equal ['13.456', '51.234']
+      delocalized_params[:interval].must_equal [Date.civil(2013, 12, 25), Date.civil(2014, 1, 31)]
+    end
   end
 end


### PR DESCRIPTION
Prior to this it was not possible to delocalize parameter arrays. This change allows to delocalize them by wrapping the parser type in an array. 

For example using a Rails point column (which are currently represented using a two-element array) this allows delocalizing its components:

```ruby
delocalize(coords: [:number])
```
The syntax is inspired by strong_parameters which already requires this:

```ruby
params.require(:poi).permit(coords: [])
```

Full example:
```ruby
params.require(:poi).permit(:distance, coords: []).
    delocalize(distance: :number, coords: [:number])
```