### PR TITLE
Fix parsing of invalid dates

### DIFF
--- a/lib/delocalize/parameter_delocalizing.rb
+++ b/lib/delocalize/parameter_delocalizing.rb
@@ -24,7 +24,12 @@ module Delocalize
 
     def delocalize_parse(options, key_stack, value)
       parser = delocalize_parser_for(options, key_stack)
-      parser ? parser.parse(value) : value
+      return value unless parser
+      begin
+        parser.parse(value)
+      rescue ArgumentError
+        value
+      end
     end
 
     def delocalize_parser_for(options, key_stack)

--- a/lib/delocalize/parsers/date_time.rb
+++ b/lib/delocalize/parsers/date_time.rb
@@ -51,7 +51,7 @@ module Delocalize
 
         today = Date.current
         parsed = Date._parse(datetime)
-        return if parsed.empty? # the datetime value is invalid
+        raise ArgumentError, "invalid date: #{datetime}" if parsed.empty? # the datetime value is invalid
 
         # set default year, month and day if not found
         parsed.reverse_merge!(:year => today.year, :mon => today.mon, :mday => today.mday)

--- a/test/date_time_parser_test.rb
+++ b/test/date_time_parser_test.rb
@@ -100,6 +100,16 @@ describe Delocalize::Parsers::DateTime do
     @time_parser.parse('9:00 Uhr').must_equal time
   end
 
+  it "raises ArgumentError when parsing a bad string" do
+    err = proc { @date_parser.parse("asdf") }.must_raise ArgumentError
+    err.message.must_equal "invalid date: asdf"
+  end
+
+  it "raises ArgumentError when parsing a bad date" do
+    must_raise_invalid_date { @date_parser.parse("02.0.2017") }
+    must_raise_invalid_date { @date_parser.parse("02.99.2017") }
+  end
+
   def must_raise_invalid_date
     begin
       yield

--- a/test/parameters_test.rb
+++ b/test/parameters_test.rb
@@ -171,5 +171,15 @@ parameters_classes.each do |parameters_class|
       delocalized_params[:location].must_equal ['13.456', '51.234']
       delocalized_params[:interval].must_equal [Date.civil(2013, 12, 25), Date.civil(2014, 1, 31)]
     end
+
+    it "keeps invalid dates in the params hash" do
+      params = parameters_class.new(:first_date => "asdf", :second_date => "02.0.2017", :third_date => "02.123.2017")
+
+      delocalized_params = params.delocalize(:first_date => :date, :second_date => :date, :third_date => :date)
+
+      delocalized_params[:first_date].must_equal "asdf"
+      delocalized_params[:second_date].must_equal "02.0.2017"
+      delocalized_params[:third_date].must_equal "02.123.2017"
+    end
   end
 end


### PR DESCRIPTION
This is a fix for #12. It contains 2 changes.

This first change makes `Delocalize::Parsers::DateTime#parse` always raise an AgrumentError when parsing an invalid date.

Before:
```
001:0:> Delocalize::Parsers::DateTime.new(Date).parse("asdf")
=> nil
002:0:> Delocalize::Parsers::DateTime.new(Date).parse("02/0/2017")
ArgumentError: invalid date
```
After:
```
001:0:> Delocalize::Parsers::DateTime.new(Date).parse("asdf")
ArgumentError: invalid date
002:0:> Delocalize::Parsers::DateTime.new(Date).parse("02/0/2017")
ArgumentError: invalid date
```

The second change makes `Delocalize::ParameterDelocalizing#delocalize_parse` catch ArgumentError's and keep the original value in the params hash. This allows the invalid values to be passed to validations and proper handling performed.

Before:
```
001:0:> ActionController::Parameters.new({first_date: "asdf"}).delocalize(first_date: :date)
=> {"first_date" => nil}
002:0:> ActionController::Parameters.new({first_date: "02/0/2017"}).delocalize(first_date: :date)
ArgumentError: invalid date
```
After:
```
001:0:> ActionController::Parameters.new({first_date: "asdf"}).delocalize(first_date: :date)
=> {"first_date" => "asdf"}
002:0:> ActionController::Parameters.new({first_date: "02/0/2017"}).delocalize(first_date: :date)
=> {"first_date" => "02/0/2017"}
```