### PR TITLE
Remove mocha gem

### DIFF
--- a/ci/Gemfile.rails42.lock
+++ b/ci/Gemfile.rails42.lock
@@ -53,14 +53,11 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
-    metaclass (0.0.4)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
-    mocha (1.2.1)
-      metaclass (~> 0.0.1)
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     rack (1.6.5)
@@ -316,7 +313,6 @@ DEPENDENCIES
   jdbc-sqlite3
   mime-types (~> 2.99.3)
   minitest
-  mocha
   rails (~> 4.2.4)
   rake
   rubysl (~> 2.0)

--- a/ci/Gemfile.rails50.lock
+++ b/ci/Gemfile.rails50.lock
@@ -56,15 +56,12 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
-    metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
-    mocha (1.2.1)
-      metaclass (~> 0.0.1)
     nio4r (2.0.0)
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
@@ -323,7 +320,6 @@ DEPENDENCIES
   jdbc-sqlite3
   mime-types (~> 2.99.3)
   minitest
-  mocha
   rails (~> 5.0.0)
   rake
   rubysl (~> 2.0)

--- a/delocalize.gemspec
+++ b/delocalize.gemspec
@@ -15,6 +15,5 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'rails', '>= 2'
-  s.add_development_dependency 'mocha'
   s.add_development_dependency 'timecop'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,6 @@ Bundler.require(:default, :development)
 
 require 'minitest/autorun'
 require 'minitest/spec'
-require 'mocha/setup'
 
 require 'rails'
 # We need to explicitly load ActiveSupport's version of Hash#slice since Rails 3.2 somehow loads


### PR DESCRIPTION
Mocha isn't used anywhere in the tests so I figured it could be removed. If you have reasons for keeping it go ahead and close this PR.