### PR TITLE
Remove database related items from testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'http://rubygems.org'
 
-gem 'sqlite3', platforms: [:ruby, :mswin, :mingw]
-gem 'jdbc-sqlite3', platform: :jruby
-gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
-
 gemspec

--- a/ci/Gemfile.rails42
+++ b/ci/Gemfile.rails42
@@ -2,13 +2,7 @@ source 'http://rubygems.org'
 
 gem 'rails', '~> 4.2.4'
 
-platforms :ruby, :mswin, :mingw do
-  gem 'sqlite3'
-end
-
 platforms :jruby do
-  gem 'jdbc-sqlite3'
-  gem 'activerecord-jdbcsqlite3-adapter'
   gem 'mime-types', '~> 2.99.3'
   gem 'rake'
 end

--- a/ci/Gemfile.rails42.lock
+++ b/ci/Gemfile.rails42.lock
@@ -297,7 +297,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.6)
     timecop (0.8.1)
@@ -308,15 +307,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord-jdbcsqlite3-adapter
   delocalize!
-  jdbc-sqlite3
   mime-types (~> 2.99.3)
   minitest
   rails (~> 4.2.4)
   rake
   rubysl (~> 2.0)
-  sqlite3
   timecop
 
 BUNDLED WITH

--- a/ci/Gemfile.rails50
+++ b/ci/Gemfile.rails50
@@ -2,13 +2,7 @@ source 'http://rubygems.org'
 
 gem 'rails', '~> 5.0.0'
 
-platforms :ruby, :mswin, :mingw do
-  gem 'sqlite3'
-end
-
 platforms :jruby do
-  gem 'jdbc-sqlite3'
-  gem 'activerecord-jdbcsqlite3-adapter'
   gem 'mime-types', '~> 2.99.3'
   gem 'rake'
 end

--- a/ci/Gemfile.rails50.lock
+++ b/ci/Gemfile.rails50.lock
@@ -301,7 +301,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.6)
     timecop (0.8.1)
@@ -315,15 +314,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord-jdbcsqlite3-adapter
   delocalize!
-  jdbc-sqlite3
   mime-types (~> 2.99.3)
   minitest
   rails (~> 5.0.0)
   rake
   rubysl (~> 2.0)
-  sqlite3
   timecop
 
 BUNDLED WITH

--- a/ci/Gemfile.rails51
+++ b/ci/Gemfile.rails51
@@ -2,13 +2,7 @@ source 'http://rubygems.org'
 
 gem 'rails', '~> 5.1.0'
 
-platforms :ruby, :mswin, :mingw do
-  gem 'sqlite3'
-end
-
 platforms :jruby do
-  gem 'jdbc-sqlite3'
-  gem 'activerecord-jdbcsqlite3-adapter'
   gem 'mime-types', '~> 2.99.3'
   gem 'rake'
 end

--- a/ci/Gemfile.rails51.lock
+++ b/ci/Gemfile.rails51.lock
@@ -301,7 +301,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.6)
     timecop (0.8.1)
@@ -315,15 +314,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord-jdbcsqlite3-adapter
   delocalize!
-  jdbc-sqlite3
   mime-types (~> 2.99.3)
   minitest
   rails (~> 5.1.0)
   rake
   rubysl (~> 2.0)
-  sqlite3
   timecop
 
 BUNDLED WITH

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,3 +1,0 @@
-test:
-  adapter: sqlite3
-  database: ":memory:"


### PR DESCRIPTION
Since delocalize is no longer integrated with ActiveRecord there is no
need to install sqlite gems or have a database.yml file for test.