### PR TITLE
Number parser verifies if its already parsed

### DIFF
--- a/lib/delocalize/parsers/number.rb
+++ b/lib/delocalize/parsers/number.rb
@@ -8,7 +8,11 @@ module Delocalize
         return value unless value.is_a?(String)
 
         separator, delimiter = I18n.t([:separator, :delimiter], :scope => :'number.format')
-        value.gsub(delimiter, '').gsub(separator, '.')
+        if value.index(separator).present? || (delimiter != '.' || (value.count('.') > 1))
+          value.gsub(delimiter, '').gsub(separator, '.')
+        else
+          value
+        end
       end
     end
   end


### PR DESCRIPTION
Hello.
This PR will fix a problem where the number parser was clearing the true separator when trying to delocalize a number that didnt need to delocalize.  
My problem was that in i would delocalize a number like '123.456,78' to '123456.78'. Then ransack's sort_link would create a url with this number already delocalized (eg: params[:search][:number]=123456.78) then, if i clicked that sort, it would be delocalized again to '12345678'. 

Thanks